### PR TITLE
Apply snake keys to arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Have you ever needed to automatically convert JSON-style `camelBack` or `CamelCa
 
 Plissken to the rescue.
 
-This gem recursively converts all camelBack or CamelCase keys in a hash structure to snake_case.
+This gem recursively converts all camelBack or CamelCase keys in either a Hash structure, or an Array of Hashes, to snake_case.
 
 ## Installation
 
@@ -22,10 +22,20 @@ gem install plissken
 
 ## Usage
 
+On hashes:
+
 ```ruby
-my_hash = {"firstKey" => 1, "fooBars" => [{"bazBaz" => "value"}, {"blahBlah" => "value"}]}
+my_hash = { "firstKey" => 1, "fooBars" => [{ "bazBaz" => "value" }, { "blahBlah" => "value" }] }
 snaked_hash = my_hash.to_snake_keys
-# => {"first_key" => 1, "foo_bars" => [{"baz_baz" => "value"}, {"blah_blah" => "value"}]}
+# => { "first_key" => 1, "foo_bars" => [{ "baz_baz" => "value" }, { "blah_blah" => "value" }] }
+```
+
+On arrays:
+
+```ruby
+my_array_of_hashes = [{ "firstKey" => 1, "fooBars" => [{ "bazBaz" => "value" }, { "blahBlah" => "value" }] }]
+snaked_hash = my_array_of_hashes.to_snake_keys
+# => [{"first_key" => 1, "foo_bars" => [{ "baz_baz" => "value" }, { "blah_blah" => "value" }] }]
 ```
 
 Plissken works on either string keys or symbolized keys. It has no dependencies, as it has its own `underscore` method lifted out of ActiveSupport.

--- a/lib/plissken.rb
+++ b/lib/plissken.rb
@@ -1,5 +1,5 @@
-require File.dirname(__FILE__) + '/plissken/ext/hash/to_snake_keys'
+require "plissken/methods"
+require "plissken/ext/hash/to_snake_keys"
 
 module Plissken
-
 end

--- a/lib/plissken.rb
+++ b/lib/plissken.rb
@@ -1,4 +1,5 @@
 require "plissken/methods"
+require "plissken/ext/array/to_snake_keys"
 require "plissken/ext/hash/to_snake_keys"
 
 module Plissken

--- a/lib/plissken/ext/array/to_snake_keys.rb
+++ b/lib/plissken/ext/array/to_snake_keys.rb
@@ -1,4 +1,4 @@
-class Hash
+class Array
 
   include Plissken::Methods
 

--- a/lib/plissken/ext/hash/to_snake_keys.rb
+++ b/lib/plissken/ext/hash/to_snake_keys.rb
@@ -1,47 +1,8 @@
-# frozen_string_literal: true
+
 
 # Hash.to_snake_keys
 class Hash
-  # Recursively converts CamelCase and camelBack JSON-style hash keys to
-  # Rubyish snake_case, suitable for use during instantiation of Ruby
-  # model attributes.
-  #
-  def to_snake_keys(value = self)
-    case value
-    when Array
-      value.map { |v| to_snake_keys(v) }
-    when Hash
-      snake_hash(value)
-    else
-      value
-    end
-  end
 
-  private
+  include Plissken::Methods
 
-  def snake_hash(value)
-    Hash[value.map { |k, v| [underscore_key(k), to_snake_keys(v)] }]
-  end
-
-  def underscore_key(k)
-    if k.is_a? Symbol
-      underscore(k.to_s).to_sym
-    elsif k.is_a? String
-      underscore(k)
-    else
-      k # Plissken can't snakify anything except strings and symbols
-    end
-  end
-
-  def underscore(string)
-    @__memoize_underscore ||= {}
-    return @__memoize_underscore[string] if @__memoize_underscore[string]
-    @__memoize_underscore[string] =
-      string.tr('::', '/')
-            .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
-            .gsub(/([a-z\d])([A-Z])/, '\1_\2')
-            .tr('-', '_')
-            .downcase
-    @__memoize_underscore[string]
-  end
 end

--- a/lib/plissken/methods.rb
+++ b/lib/plissken/methods.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Plissken
+  module Methods
+
+    # Recursively converts CamelCase and camelBack JSON-style hash keys to
+    # Rubyish snake_case, suitable for use during instantiation of Ruby
+    # model attributes.
+    #
+    def to_snake_keys(value = self)
+      case value
+      when Array
+        value.map { |v| to_snake_keys(v) }
+      when Hash
+        snake_hash(value)
+      else
+        value
+      end
+    end
+
+    private
+
+    def snake_hash(value)
+      Hash[value.map { |k, v| [underscore_key(k), to_snake_keys(v)] }]
+    end
+
+    def underscore_key(k)
+      if k.is_a? Symbol
+        underscore(k.to_s).to_sym
+      elsif k.is_a? String
+        underscore(k)
+      else
+        k # Plissken can't snakify anything except strings and symbols
+      end
+    end
+
+    def underscore(string)
+      @__memoize_underscore ||= {}
+      return @__memoize_underscore[string] if @__memoize_underscore[string]
+      @__memoize_underscore[string] =
+        string.tr('::', '/')
+              .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
+              .gsub(/([a-z\d])([A-Z])/, '\1_\2')
+              .tr('-', '_')
+              .downcase
+      @__memoize_underscore[string]
+    end
+
+  end
+end

--- a/test/plissken/ext/array/to_snake_keys_test.rb
+++ b/test/plissken/ext/array/to_snake_keys_test.rb
@@ -1,39 +1,39 @@
 require File.expand_path(File.dirname(__FILE__) + "/../../../test_plissken.rb")
 
-describe "Hash" do
+describe "Array" do
   describe "with camelBack keys" do
     describe "which are JSON-style strings" do
       describe "in the simplest case" do
         before do
-          @hash = { "firstKey" => "fooBar" }
+          @array = [{ "firstKey" => "fooBar" }]
         end
 
         describe "non-destructive snakification" do
           before do
-            @snaked = @hash.to_snake_keys
+            @snaked = @array.to_snake_keys
           end
 
           it "snakifies the key" do
-            assert_equal("first_key", @snaked.keys.first)
+            assert_equal("first_key", @snaked[0].keys.first)
           end
 
           it "leaves the key as a string" do
-            assert_equal("first_key", @snaked.keys.first)
+            assert_equal("first_key", @snaked[0].keys.first)
           end
 
           it "leaves the value untouched" do
-            assert_equal("fooBar", @snaked.values.first)
+            assert_equal("fooBar", @snaked[0].values.first)
           end
 
           it "leaves the original hash untouched" do
-            assert_equal("firstKey", @hash.keys.first)
+            assert_equal("firstKey", @array[0].keys.first)
           end
         end
       end
 
       describe "containing an array of other hashes" do
         before do
-          @hash = {
+          @array = [{
             "appleType" => "Granny Smith",
             "vegetableTypes" => [
               { "potatoType" => "Golden delicious" },
@@ -42,43 +42,43 @@ describe "Hash" do
                 { "billThePeanut" => "sallyPeanut" },
                 { "sammyThePeanut" => "jillPeanut" }
               ] }
-            ] }
+            ] }]
         end
 
         describe "non-destructive snakification" do
           before do
-            @snaked = @hash.to_snake_keys
+            @snaked = @array.to_snake_keys
           end
 
           it "recursively snakifies the keys on the top level of the hash" do
-            assert @snaked.keys.include?("apple_type")
-            assert @snaked.keys.include?("vegetable_types")
+            assert @snaked[0].keys.include?("apple_type")
+            assert @snaked[0].keys.include?("vegetable_types")
           end
 
           it "leaves the values on the top level alone" do
-            assert_equal("Granny Smith", @snaked["apple_type"])
+            assert_equal("Granny Smith", @snaked[0]["apple_type"])
           end
 
           it "converts second-level keys" do
-            assert @snaked["vegetable_types"].first.key? "potato_type"
+            assert @snaked[0]["vegetable_types"].first.key? "potato_type"
           end
 
           it "leaves second-level values alone" do
-            assert @snaked["vegetable_types"].first.value? "Golden delicious"
+            assert @snaked[0]["vegetable_types"].first.value? "Golden delicious"
           end
 
           it "converts third-level keys" do
-            assert @snaked["vegetable_types"].last["peanut_names_and_spouses"]
+            assert @snaked[0]["vegetable_types"].last["peanut_names_and_spouses"]
               .first.key?("bill_the_peanut")
-            assert @snaked["vegetable_types"].last["peanut_names_and_spouses"]
+            assert @snaked[0]["vegetable_types"].last["peanut_names_and_spouses"]
               .last.key?("sammy_the_peanut")
           end
 
           it "leaves third-level values alone" do
-            assert_equal "sallyPeanut", @snaked["vegetable_types"]
+            assert_equal "sallyPeanut", @snaked[0]["vegetable_types"]
               .last["peanut_names_and_spouses"]
               .first["bill_the_peanut"]
-            assert_equal "jillPeanut", @snaked["vegetable_types"]
+            assert_equal "jillPeanut", @snaked[0]["vegetable_types"]
               .last["peanut_names_and_spouses"]
               .last["sammy_the_peanut"]
           end
@@ -89,35 +89,35 @@ describe "Hash" do
     describe "which are symbols" do
       describe "in the simplest case" do
         before do
-          @hash = { :firstKey => "fooBar" }
+          @array = [{ :firstKey => "fooBar" }]
         end
 
         describe "non-destructive snakification" do
           before do
-            @snaked = @hash.to_snake_keys
+            @snaked = @array.to_snake_keys
           end
 
           it "snakifies the key" do
-            assert_equal(:first_key, @snaked.keys.first)
+            assert_equal(:first_key, @snaked[0].keys.first)
           end
 
           it "leaves the key as a symbol" do
-            assert_equal(:first_key, @snaked.keys.first)
+            assert_equal(:first_key, @snaked[0].keys.first)
           end
 
           it "leaves the value untouched" do
-            assert_equal("fooBar", @snaked.values.first)
+            assert_equal("fooBar", @snaked[0].values.first)
           end
 
           it "leaves the original hash untouched" do
-            assert_equal(:firstKey, @hash.keys.first)
+            assert_equal(:firstKey, @array[0].keys.first)
           end
         end
       end
 
       describe "containing an array of other hashes" do
         before do
-          @hash = {
+          @array = [{
             :appleType => "Granny Smith",
             :vegetableTypes => [
               { :potatoType => "Golden delicious" },
@@ -125,44 +125,45 @@ describe "Hash" do
               { :peanutNamesAndSpouses => [
                 { :billThePeanut => "sallyPeanut" },
                 { :sammyThePeanut => "jillPeanut" }
-              ] }
-            ] }
+              ]
+              }]
+            }]
         end
 
         describe "non-destructive snakification" do
           before do
-            @snaked = @hash.to_snake_keys
+            @snaked = @array.to_snake_keys
           end
 
           it "recursively snakifies the keys on the top level of the hash" do
-            assert @snaked.keys.include?(:apple_type)
-            assert @snaked.keys.include?(:vegetable_types)
+            assert @snaked[0].keys.include?(:apple_type)
+            assert @snaked[0].keys.include?(:vegetable_types)
           end
 
           it "leaves the values on the top level alone" do
-            assert_equal(@snaked[:apple_type], "Granny Smith")
+            assert_equal("Granny Smith", @snaked[0][:apple_type])
           end
 
           it "converts second-level keys" do
-            assert @snaked[:vegetable_types].first.key? :potato_type
+            assert @snaked[0][:vegetable_types].first.key? :potato_type
           end
 
           it "leaves second-level values alone" do
-            assert @snaked[:vegetable_types].first.value? "Golden delicious"
+            assert @snaked[0][:vegetable_types].first.value? "Golden delicious"
           end
 
           it "converts third-level keys" do
-            assert @snaked[:vegetable_types].last[:peanut_names_and_spouses]
+            assert @snaked[0][:vegetable_types].last[:peanut_names_and_spouses]
               .first.key?(:bill_the_peanut)
-            assert @snaked[:vegetable_types].last[:peanut_names_and_spouses]
+            assert @snaked[0][:vegetable_types].last[:peanut_names_and_spouses]
               .last.key?(:sammy_the_peanut)
           end
 
           it "leaves third-level values alone" do
-            assert_equal "sallyPeanut", @snaked[:vegetable_types]
+            assert_equal "sallyPeanut", @snaked[0][:vegetable_types]
               .last[:peanut_names_and_spouses]
               .first[:bill_the_peanut]
-            assert_equal "jillPeanut", @snaked[:vegetable_types]
+            assert_equal "jillPeanut", @snaked[0][:vegetable_types]
               .last[:peanut_names_and_spouses]
               .last[:sammy_the_peanut]
           end
@@ -173,12 +174,12 @@ describe "Hash" do
 
   describe "strings with spaces in them" do
     before do
-      @hash = { "With Spaces" => "FooBar" }
-      @snaked = @hash.to_snake_keys
+      @array = [{ "With Spaces" => "FooBar" }]
+      @snaked = @array.to_snake_keys
     end
 
     it "doesn't get snaked, although it does get downcased" do
-      assert @snaked.keys.include? "with spaces"
+      assert @snaked[0].keys.include? "with spaces"
     end
   end
 end


### PR DESCRIPTION
The `.to_snake_keys` method can now be applied to both Hash and Array objects, meaning you can call it directly on a JSON parsed array to snake key an of its objects.